### PR TITLE
update README.md about firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,28 @@ To login as the root user, run
 docker exec -it oacis bash
 ```
 
+## Firewall
+
+Linux users must set up firewall for oacis_docker, or any one can access to your oacis via oacis web browser interface.
+Run the following command by root user.
+
+```sh
+iptables -I FORWARD -i eth+ -o docker0 -p tcp -m tcp --dport 3000 -j DROP
+```
+
+If you also use wifi network, additionarry run the following command.
+
+```sh
+iptables -I FORWARD -i wlan+ -o docker0 -p tcp -m tcp --dport 3000 -j DROP
+```
+
+Note: `iptables` is an application programm for Linux kernel firewall and the configurations are deleted when host OS reboots.
+Note: If you will allow to access to oacis over the firewall, run the following command.
+
+```sh
+iptables -I FORWARD -i eth+ -o docker0 -d $(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' oacis) -p tcp -m tcp --dport 3000 -j ACCEPT
+```
+
 ## More infomation
 
 See [wiki](https://github.com/crest-cassia/oacis_docker/wiki).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ docker exec -it oacis bash
 ## Firewall
 
 Linux users must set up firewall for oacis_docker, or any one can access to your oacis via oacis web browser interface.
-Run the following command by root user.
+`iptables` is an application programm for Linux kernel firewall and docker-engine makes iptables configulations.
+Run the following command by root user on host machine to overwrite the configulations.
 
 ```sh
 iptables -I FORWARD -i eth+ -o docker0 -p tcp -m tcp --dport 3000 -j DROP
@@ -97,7 +98,7 @@ If you also use wifi network, additionarry run the following command.
 iptables -I FORWARD -i wlan+ -o docker0 -p tcp -m tcp --dport 3000 -j DROP
 ```
 
-Note: `iptables` is an application programm for Linux kernel firewall and the configurations are deleted when host OS reboots.
+Note: `iptables` configurations are deleted when host OS reboots.
 Note: If you will allow to access to oacis over the firewall, run the following command.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -84,22 +84,23 @@ docker exec -it oacis bash
 
 ## Firewall
 
-Linux users must set up firewall for oacis_docker, or any one can access to your oacis via oacis web browser interface.
-`iptables` is an application programm for Linux kernel firewall and docker-engine makes iptables configulations.
-Run the following command by root user on host machine to overwrite the configulations.
+Linux users must set up firewall for oacis_docker, otherwise anyone can access your oacis web-browser interface.
+`iptables` is an application program for setting up firewall and docker-engine makes iptables configulations.
+Run the following command as root on host machine to overwrite the configulations.
 
 ```sh
 iptables -I FORWARD -i eth+ -o docker0 -p tcp -m tcp --dport 3000 -j DROP
 ```
 
-If you also use wifi network, additionarry run the following command.
+If you are also using wifi, you need to run the following command additionally.
 
 ```sh
 iptables -I FORWARD -i wlan+ -o docker0 -p tcp -m tcp --dport 3000 -j DROP
 ```
 
 Note: `iptables` configurations are deleted when host OS reboots.
-Note: If you will allow to access to oacis over the firewall, run the following command.
+
+Note: If you would like to allow others to access oacis, run the following command.
 
 ```sh
 iptables -I FORWARD -i eth+ -o docker0 -d $(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' oacis) -p tcp -m tcp --dport 3000 -j ACCEPT


### PR DESCRIPTION
# iptablesを利用したfirewall設定方法
- dockerのデフォルト設定では，eth0とdocker0間のFORWARD通信がすべて許可されています．
- OACISへアクセスする通信を遮断するルールを追加します．
- 外部ユーザにOACISを公開したい場合には，コンテナごとに個別に設定を行います．