### PR TITLE
use supervisorctl

### DIFF
--- a/oacis_start.sh
+++ b/oacis_start.sh
@@ -5,7 +5,7 @@ chown -R 999:999 /data/db
 chown -R oacis:oacis /home/oacis/oacis/public/Result_development
 
 #start mongod and sshd
-/usr/bin/supervisord
+supervisorctl start
 
 #waiting for mongod boot
 until [ "$(mongo --eval 'printjson(db.serverStatus().ok)' | tail -1 | tr -d '\r')" == "1" ]


### PR DESCRIPTION
- old
    - up supervisord daemon

`/usr/bin/supervisord`
- new
    - up supervisord daemon if the daemon is stopped
    - up daemons(mongo, ssh)

`supervisorctl start`