### PR TITLE
a bug on setup_ns_model.sh is fixed

### DIFF
--- a/oacis/setup_ns_model.sh
+++ b/oacis/setup_ns_model.sh
@@ -3,5 +3,5 @@ set -eux
 git clone https://github.com/yohm/nagel_schreckenberg_model.git
 cd nagel_schreckenberg_model
 bundle install --path=vendor/bundle
-$OACIS_ROOT/bin/oacis_ruby register_to_oacis.rb
+$OACIS_ROOT/bin/oacis_ruby register_on_oacis.rb
 


### PR DESCRIPTION
A serious bug was found when international conference school was taken place.
The name of script written in setup script was not consistent with downloaded script file name.