### PR TITLE
change uid and gid instead of chown

### DIFF
--- a/oacis/README.md
+++ b/oacis/README.md
@@ -86,10 +86,11 @@ $ docker rmi oacis/oacis         # removing the image of OACIS
 
 ## Mounting a directory
 
-Simulation results are stored in "/home/oacis/oacis/public/Result_development" directory. You can mount a directory of the host machine to this directory.
+Simulation results are stored in "/home/oacis/oacis/public/Result_development" directory in the container. You can mount this directory to a directory in the host machine with `-v` option.
+When mounting the directroy, you also need to set `-e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER)` options. This is because the user in the container must have the same uid and gid as those in the local host to access the mounted directory properly. By these options, local uid and gid are sent to the container as environment variables.
 
 ```
-docker run --name my_oacis -p 127.0.0.1:3000:3000 -v $(pwd):/home/oacis/oacis/public/Result_development -dt oacis/oacis
+docker run --name my_oacis -p 127.0.0.1:3000:3000 -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -v $(pwd):/home/oacis/oacis/public/Result_development -dt oacis/oacis
 ```
 
 ## Backup and Restore

--- a/oacis/oacis_start.sh
+++ b/oacis/oacis_start.sh
@@ -2,7 +2,8 @@
 
 #pre-processes
 chown -R 999:999 /data/db
-chown -R oacis:oacis /home/oacis/oacis/public/Result_development
+usermod -u ${LOCAL_UID:-1000} oacis
+groupmod -g ${LOCAL_GID:-1000} oacis
 
 #start mongod and sshd
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/oacis/oacis_start.sh
+++ b/oacis/oacis_start.sh
@@ -3,7 +3,7 @@
 #pre-processes
 chown -R 999:999 /data/db
 groupmod -g ${LOCAL_GID:-1000} oacis
-usermod -g ${LOCAL_GID:1000} -u ${LOCAL_UID:-1000} oacis
+usermod -g ${LOCAL_GID:-1000} -u ${LOCAL_UID:-1000} oacis
 chown -R oacis:oacis /usr/local/bundle
 
 #start mongod and sshd

--- a/oacis/oacis_start.sh
+++ b/oacis/oacis_start.sh
@@ -2,8 +2,9 @@
 
 #pre-processes
 chown -R 999:999 /data/db
-usermod -u ${LOCAL_UID:-1000} oacis
 groupmod -g ${LOCAL_GID:-1000} oacis
+usermod -g ${LOCAL_GID:1000} -u ${LOCAL_UID:-1000} oacis
+chown -R oacis:oacis /usr/local/bundle
 
 #start mongod and sshd
 /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
fixed #66 

テスト方法

- oacisディレクトリにて `docker build . -t oacis_test`
- `mkdir -p temp`
- `docker run --name test -p 3010:3000 -e LOCAL_UID=$(id -u $USER) -e LOCAL_GID=$(id -g $USER) -dt -v $(pwd)/temp:/home/oacis/oacis/public/Result_development oacis_test`
- tempディレクトリのpermissionが自分のuid,gidであることを確認する
- oacisを操作して、simulatorが作成できることを確認する
- `docker stop test && docker rm -v test && docker image rm oacis_test`
