### PR TITLE
set USER in bash_profile

### DIFF
--- a/oacis/Dockerfile
+++ b/oacis/Dockerfile
@@ -34,6 +34,7 @@ RUN git clone --recursive https://github.com/crest-cassia/oacis.git \
     && echo "unset BUNDLE_APP_CONFIG" >> /home/oacis/.bash_profile \
     && echo "export BUNDLE_PATH=$BUNDLE_PATH" >> /home/oacis/.bash_profile \
     && echo "export OACIS_ROOT=/home/oacis/oacis" >> /home/oacis/.bash_profile \
+    && echo 'export USER=$(whoami)' >> /home/oacis/.bash_profile \
     && mkdir -p /home/oacis/oacis/public/Result_development
 
 #put oacis_start.sh


### PR DESCRIPTION
When ENV['USER'] is not set, SSH commands are not properly executed because Net::SSH module seems to refer to ENV['USER'] instead of `$(whoami)` to get the user name.
In the current docker container, ENV['USER'] is somehow left unset in the shell started by `docker exec -it -u oacis my_oacis /bin/bash -l` command. Thus, saving a Host object fails because the validation of host parameters fails, which prevents us from registering a new simulator using APIs.

To dissolve this problem, we set `ENV['USER']` in .bash_profile to ensure that the environment variable is properly set.
