### PR TITLE
specify Miniconda 4.5.11

### DIFF
--- a/oacis_jupyter/Dockerfile
+++ b/oacis_jupyter/Dockerfile
@@ -15,11 +15,13 @@ RUN apt-get update \
 USER oacis
 WORKDIR /home/oacis
 ENV HOME /home/oacis
-RUN wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-4.5.11-Linux-x86_64.sh \
     && bash conda.sh -b \
+    && ~/miniconda3/bin/conda clean -tipsy \
     && rm conda.sh \
-    && echo 'export PATH=/home/oacis/miniconda3/bin:$PATH' >> ~/.bash_profile \
     && echo 'export LANG=C.UTF-8' >> ~/.bash_profile \
+    && echo '. /home/oacis/miniconda3/etc/profile.d/conda.sh' >> ~/.bash_profile \
+    && echo "conda activate base" >> ~/.bash_profile \
     && . ~/.bash_profile \
     && conda install -y \
         python=3.5 \
@@ -27,6 +29,7 @@ RUN wget -O conda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux
         pandas \
         matplotlib \
         jupyter \
+    && conda clean -tipsy \
     && pip install msgpack-rpc-python fibers \
     && mkdir -p ~/.jupyter \
     && echo 'c.NotebookApp.token = ""' > ~/.jupyter/jupyter_notebook_config.py \


### PR DESCRIPTION
The current latest version Miniconda 4.5.12 seems to have a bug. When installing python3.5, it conflicts with enum34 package.

```
Solving environment: ...working... failed

UnsatisfiableError: The following specifications were found to be in conflict:
  - conda[version='>=4.5.12'] -> enum34 -> python[version='>=2.7,<2.8.0a0']
  - python=3.5
Use "conda info <package>" to see the dependencies for each package.
```

Presumably, this is related to https://github.com/conda/conda/issues/8054
To avoid this issue, we downgraded miniconda to 4.5.11.

We upgraded other settings (`conda activate base` and sourcing conda.sh) to conform to the specification of miniconda 4.
