### PR TITLE
move packages to base image

### DIFF
--- a/oacis/Dockerfile
+++ b/oacis/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF505
         rsync \
         supervisor \
         vim \
+        less \
+        bash-completion \
     && apt-get clean \
     && mkdir -p /var/run/sshd \
     && cp /etc/redis/redis.conf /etc/redis/redis.conf.org \

--- a/oacis_jupyter/Dockerfile
+++ b/oacis_jupyter/Dockerfile
@@ -4,14 +4,6 @@
 FROM oacis/oacis:latest
 MAINTAINER "OACIS developers" <oacis-dev@googlegroups.com>
 
-USER root
-RUN apt-get update \
-    && apt-get install -y \
-        less \
-        bash-completion \
-        gnuplot \
-    && apt-get clean
-
 USER oacis
 WORKDIR /home/oacis
 ENV HOME /home/oacis


### PR DESCRIPTION
Moved "less" and "bash-completion" to the base image. "gnuplot" was removed since it is not used in the tutorials.

The image size changes
- oacis : 1.39GB -> 1.39 GB
- oacis_jupyter : 3.46GB -> 3.26 GB