### PR TITLE
fix: SSH_AUTH_SOCK was not properly set

### DIFF
--- a/oacis/oacis_start.sh
+++ b/oacis/oacis_start.sh
@@ -53,9 +53,11 @@ fi
 
 #run oacis
 # pre-compile assets to accelerate the boot
-su - -m -c "\
+su - -c "
+  export RAILS_ENV=production && \
+  export SSH_AUTH_SOCK=$SSH_AUTH_SOCK && \
   cd /home/oacis/oacis && \
-  env RAILS_ENV=production bin/rails assets:precompile && \
+  bin/rails assets:precompile && \
   bundle exec rake daemon:restart && \
   if [ ! -f ~/.ssh/id_rsa ]; \
   then \


### PR DESCRIPTION
`-m` option (preserver environment variables) in `su` command was not compatible with `su -` (starts a login shell for the user oacis). As a result, environment variable `SSH_AUTH_SOCK` was not properly set which prevents OACIS to access docker-host.