### PR TITLE
Improve Docker service health and CI readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: OACIS CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "**" ]
   pull_request:
     branches: [ master ]
+
+concurrency:
+  group: oacis-ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   build-and-test:
@@ -14,40 +18,86 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate Docker Compose configuration
+        run: docker compose config --quiet
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Boot OACIS with multi-container setup
         run: ./oacis_boot.sh --build-image develop --image-tag test
+        env:
+          OACIS_HEALTH_TIMEOUT: 600
 
-      - name: Wait for OACIS to be ready
+      - name: Verify service health
         run: |
-          echo "Waiting for OACIS web server to be ready..."
-          timeout 60 bash -c 'until curl -f http://localhost:3000 > /dev/null 2>&1; do sleep 2; done'
-          echo "OACIS web server is ready"
+          ./oacis_wait_healthy.sh mongo redis oacis
+          for service in mongo redis oacis; do
+            container_id=$(docker compose ps -q "$service")
+            health=$(docker inspect --format '{{.State.Health.Status}}' "$container_id")
+            echo "$service health: $health"
+            test "$health" = healthy
+          done
 
       - name: Verify OACIS web server
         run: |
-          response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000)
-          if [ "$response" -eq 200 ]; then
-            echo "✅ OACIS web server is responding correctly (HTTP $response)"
-          else
-            echo "❌ OACIS web server returned HTTP $response"
-            exit 1
-          fi
+          response=$(curl -sS -o /dev/null -w "%{http_code}" http://localhost:3000/)
+          echo "OACIS web server HTTP status: $response"
+          test "$response" -eq 200
+
+      - name: Verify MongoDB and Redis versions
+        run: |
+          mongo_version=$(docker compose exec -T mongo mongosh --quiet --eval 'db.version()' | tr -d '\r')
+          echo "MongoDB version: $mongo_version"
+          test "$mongo_version" = "8.0.10"
+          case "$mongo_version" in
+            *-rc*) echo "MongoDB must not be an RC version"; exit 1 ;;
+          esac
+
+          redis_version=$(docker compose exec -T redis redis-cli --raw INFO server \
+            | sed -n 's/^redis_version://p' | tr -d '\r')
+          echo "Redis version: $redis_version"
+          test -n "$redis_version"
 
       - name: Verify Ruby version in the container
         run: |
           ruby_version=$(docker compose exec -T -u oacis oacis ruby -e 'print RUBY_VERSION')
           echo "Ruby version in the container: $ruby_version"
           if [[ "$ruby_version" == 3.* ]]; then
-            echo "✅ OACIS v4 is running on Ruby 3"
+            echo "OACIS is running on Ruby 3"
           else
-            echo "❌ Unexpected Ruby version: $ruby_version"
+            echo "Unexpected Ruby version: $ruby_version"
             exit 1
           fi
 
+      - name: Smoke test the OACIS MCP server
+        run: |
+          mcp_stdout=$(mktemp)
+          mcp_stderr=$(mktemp)
+          printf '%s\n' \
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"ci","version":"1"}}}' \
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' \
+            | ./oacis_mcp.sh >"$mcp_stdout" 2>"$mcp_stderr"
+
+          python3 - "$mcp_stdout" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          lines = pathlib.Path(sys.argv[1]).read_text().splitlines()
+          assert len(lines) == 2, f"expected exactly 2 protocol lines, got {len(lines)}: {lines!r}"
+          responses = [json.loads(line) for line in lines]
+          assert responses[0]["jsonrpc"] == "2.0"
+          assert responses[0]["id"] == 1
+          assert responses[0]["result"]["serverInfo"]["name"] == "oacis"
+          assert responses[1]["jsonrpc"] == "2.0"
+          assert responses[1]["id"] == 2
+          assert responses[1]["result"]["tools"]
+          PY
+
+          echo "MCP stderr (diagnostic channel):"
+          cat "$mcp_stderr"
+
       - name: Cleanup containers
         if: always()
-        run: ./oacis_terminate.sh || true
-
+        run: ./oacis_terminate.sh --force || docker compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,18 @@ jobs:
 
       - name: Verify MongoDB and Redis versions
         run: |
+          mongo_image=$(docker compose config --images mongo)
+          expected_mongo_version=${mongo_image##*:}
+          echo "MongoDB image: $mongo_image"
+          case "$expected_mongo_version" in
+            8.0.*-rc*) echo "MongoDB must not use an RC image: $mongo_image"; exit 1 ;;
+            8.0.*) ;;
+            *) echo "MongoDB must use a versioned stable 8.0 image: $mongo_image"; exit 1 ;;
+          esac
+
           mongo_version=$(docker compose exec -T mongo mongosh --quiet --eval 'db.version()' | tr -d '\r')
           echo "MongoDB version: $mongo_version"
-          test "$mongo_version" = "8.0.10"
-          case "$mongo_version" in
-            *-rc*) echo "MongoDB must not be an RC version"; exit 1 ;;
-          esac
+          test "$mongo_version" = "$expected_mongo_version"
 
           redis_version=$(docker compose exec -T redis redis-cli --raw INFO server \
             | sed -n 's/^redis_version://p' | tr -d '\r')

--- a/MIGRATION_V3_TO_V4.md
+++ b/MIGRATION_V3_TO_V4.md
@@ -8,7 +8,8 @@ This guide describes how to upgrade an existing oacis_docker installation from O
 - **Python API removed**: `bin/oacis_python` and the Python version of `OacisWatcher` are no longer included. See [If you used the Python API](#if-you-used-the-python-api) below.
 - **New: MCP server**: AI agents can create parameter sets, submit and monitor runs, and read results through `bin/oacis_mcp`. See the [MCP section of the README](README.md#mcp-server-for-ai-agents-oacis-v4).
 - **Session secret**: v4 generates a per-installation session secret on first boot. You will be logged out of the web UI once after the upgrade (and whenever the container is recreated). This is harmless.
-- **Unchanged**: the MongoDB and Redis service containers, the exposed port (3000), the `Result` directory layout, and all the management scripts (`oacis_boot.sh`, `oacis_dump_db.sh`, etc.) work the same way.
+- **Service health**: the multi-container setup uses stable MongoDB 8.0 and healthchecks for MongoDB, Redis, and OACIS. OACIS starts only after MongoDB and Redis are healthy.
+- **Unchanged**: the exposed port (3000), the `Result` directory layout, and the management-script command names (`oacis_boot.sh`, `oacis_dump_db.sh`, etc.) remain the same.
 
 ## 0. Back up your data first (required)
 
@@ -69,6 +70,8 @@ Nothing changes on your remote hosts. Ruby 3 is required only by OACIS itself, w
 
 ## Troubleshooting
 
-- Check the logs: `docker compose logs oacis` and `docker compose logs mongo`.
-- `./oacis_restore_db.sh` fails: OACIS must be running — run `./oacis_boot.sh` first, wait for "OACIS READY", then retry.
+- Check `docker compose ps`; the `mongo`, `redis`, and `oacis` services should show `healthy`.
+- Startup waits at most 10 minutes by default. Set `OACIS_HEALTH_TIMEOUT` to override the limit.
+- Check the logs: `docker compose logs oacis`, `docker compose logs mongo`, and `docker compose logs redis`.
+- `./oacis_restore_db.sh` fails: OACIS must be running — run `./oacis_boot.sh` first, confirm that `docker compose ps` reports OACIS as `healthy`, then retry.
 - The web UI does not come up after upgrading: run `./oacis_shell.sh` and check `~/oacis/log/production.log`.

--- a/README.md
+++ b/README.md
@@ -54,12 +54,49 @@ $ ./oacis_boot.sh
 ```
 
 A container of OACIS launches. It takes some time until the launch completes.
+The Compose stack uses the stable MongoDB 8.0 series (currently `mongo:8.0.10`)
+and waits for MongoDB and Redis to become healthy before starting OACIS.
+`oacis_boot.sh` returns after the OACIS container's HTTP healthcheck succeeds.
 
 - Visit http://localhost:3000 to access OACIS like the following. You may change the port by specifying `-p` option.
 
 <img src="./fig/top.png" width="600" style="display: block; margin: auto;">
 
 See [OACIS documentation](http://crest-cassia.github.io/oacis/).
+
+### Checking container health
+
+Run the following command to inspect all three services:
+
+```shell
+$ docker compose ps
+```
+
+The `mongo`, `redis`, and `oacis` services should all show `healthy`. MongoDB is
+checked with an administrative ping after first-run initialization is complete,
+Redis must answer `PONG`, and OACIS must return a successful response from
+`http://localhost:3000/` inside its container.
+
+Both `oacis_boot.sh` and `oacis_start.sh` stop waiting and return a non-zero
+status if a service becomes unhealthy or OACIS does not become healthy within
+10 minutes. Override the limit in seconds with `OACIS_HEALTH_TIMEOUT`, for
+example:
+
+```shell
+$ OACIS_HEALTH_TIMEOUT=900 ./oacis_boot.sh
+```
+
+On failure, the scripts print `docker compose ps` and recent logs for OACIS,
+MongoDB, and Redis. To inspect them again, run:
+
+```shell
+$ docker compose logs oacis
+$ docker compose logs mongo
+$ docker compose logs redis
+```
+
+These Compose changes do not pin the OACIS image tag, the OACIS Git source
+reference used for local builds, the Ruby base image, or the xsub version.
 
 ### 3. stopping the container temporarily
 

--- a/README.md
+++ b/README.md
@@ -139,12 +139,22 @@ The source code of this sample simulator can be found at [yohm/sim_ns_model](htt
 
 ## MCP server for AI agents (OACIS v4)
 
-OACIS v4 ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, which lets AI agents such as Claude create parameter sets, submit and monitor runs, read result files, and trigger analyzers.
-Use the `oacis_mcp.sh` wrapper script to launch it inside the running container. For instance, register it to [Claude Code](https://claude.com/claude-code) as follows:
+OACIS v4 ships an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, which lets AI agents such as Claude and Codex create parameter sets, submit and monitor runs, read result files, and trigger analyzers.
+Use the `oacis_mcp.sh` wrapper script to launch it inside the running container. Register it with your AI agent as follows.
+
+### Claude Code
 
 ```shell
 claude mcp add oacis -- /path/to/oacis_docker/oacis_mcp.sh
 ```
+
+### Codex
+
+```shell
+codex mcp add oacis -- /path/to/oacis_docker/oacis_mcp.sh
+```
+
+Confirm that Codex has registered the server with `codex mcp list`. Start a new Codex session before using the OACIS tools.
 
 The server speaks JSON-RPC over stdio; it opens no network port. OACIS must be running (`./oacis_boot.sh`) when the agent connects.
 See the [OACIS MCP documentation](http://crest-cassia.github.io/oacis/en/mcp.html) for the available tools and the security model.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,26 @@
 services:
   mongo:
-    image: mongo:8.0.10-rc0
+    image: mongo:8.0.10
     volumes:
       - mongo_data:/data/db
       - ./init_mongo_data.sh:/docker-entrypoint-initdb.d/init_mongo_data.sh:ro
+    healthcheck:
+      # During first-run initialization, the image temporarily starts mongod
+      # before executing init scripts. Requiring mongod to be PID 1 prevents
+      # that temporary process from being reported as ready.
+      test: ["CMD-SHELL", "test \"$$(cat /proc/1/comm)\" = mongod && mongosh --quiet --eval \"quit(db.adminCommand('ping').ok ? 0 : 1)\""]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
   redis:
     image: redis:8.0.1
+    healthcheck:
+      test: ["CMD-SHELL", "response=$$(redis-cli ping) && test \"$$response\" = PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
   oacis:
     image: oacis/oacis:${OACIS_IMAGE_TAG:-latest}
     volumes:
@@ -22,8 +37,16 @@ services:
     extra_hosts:
       - "gateway.docker.internal:host-gateway"
     depends_on:
-      - mongo
-      - redis
+      mongo:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "--max-time", "5", "http://localhost:3000/"]
+      interval: 10s
+      timeout: 10s
+      retries: 12
+      start_period: 180s
 
 volumes:
   mongo_data:

--- a/oacis_boot.sh
+++ b/oacis_boot.sh
@@ -121,34 +121,22 @@ eval "echo \"$(cat dotenv_template)\"" > .env
 
 # boot docker container
 if [ -n "${SSH_AUTH_SOCK}" ]; then
-  docker compose -f docker-compose.yml -f docker-compose.agent.yml up -d
+  if ! docker compose -f docker-compose.yml -f docker-compose.agent.yml up -d; then
+    ./oacis_wait_healthy.sh mongo redis oacis || true
+    exit 1
+  fi
 else
-  docker compose -f docker-compose.yml up -d
+  if ! docker compose -f docker-compose.yml up -d; then
+    ./oacis_wait_healthy.sh mongo redis oacis || true
+    exit 1
+  fi
 fi
 
-# show logs until OACIS is ready
-if [ -e temp.pipe ]; then
-  rm temp.pipe
-fi
-mkfifo temp.pipe
-docker compose logs -f --since 0s > >(tee temp.pipe) 2> /dev/null &
-trap "kill -9 $!" 1 2 3 15
-# equivalent to `docker compose logs ... | tee temp.pipe`
-# but we use process substitution to get the PID of `docker compose logs`
-# in case we receive the signal, we kill `docker compose logs`
 set +x
-grep --line-buffered -m 1 "OACIS READY" > /dev/null < temp.pipe
-# to stop `docker compose logs -f`, multiple signals are needed
-# probably due to a bug in this command
-while kill -0 $! 2> /dev/null; do
-  kill -2 $!
-  sleep 0.1
-done
-rm temp.pipe
+./oacis_wait_healthy.sh oacis
 
 # if dump file exists, prompt to run oacis_restore_db
 if [ -e "Result/db_dump" ]; then
   echo
   echo "===== 'Result/db_dump' file is found. Run ./oacis_restore_db.sh to restore the database ===="
 fi
-

--- a/oacis_start.sh
+++ b/oacis_start.sh
@@ -38,28 +38,18 @@ elif echo "${COMPOSE_PS_JSON}" | grep -q '"State":"running"'; then
   echo "===== container is already running ====="
   exit 1
 elif echo "${COMPOSE_PS_JSON}" | grep -q '"State":"exited"'; then
-  docker compose start
+  if ! docker compose start mongo redis; then
+    ./oacis_wait_healthy.sh mongo redis || true
+    exit 1
+  fi
+  ./oacis_wait_healthy.sh mongo redis
+  if ! docker compose start oacis; then
+    ./oacis_wait_healthy.sh oacis || true
+    exit 1
+  fi
 else
   echo "unexpected status"
   exit 1
 fi
 
-# show logs until OACIS is ready
-if [ -e temp.pipe ]; then
-  rm temp.pipe
-fi
-mkfifo temp.pipe
-docker compose logs -f --since 0s > >(tee temp.pipe) 2> /dev/null &
-trap "kill -9 $!" 1 2 3 15
-# equivalent to `docker compose logs ... | tee temp.pipe`
-# but we use process substitution to get the PID of `docker compose logs`
-# in case we receive the signal, we kill `docker compose logs`
-set +x
-grep --line-buffered -m 1 "OACIS READY" > /dev/null < temp.pipe
-# to stop `docker compose logs -f`, multiple signals are needed
-# probably due to a bug in this command
-while kill -0 $! 2> /dev/null; do
-  kill -2 $!
-  sleep 0.1
-done
-rm temp.pipe
+./oacis_wait_healthy.sh oacis

--- a/oacis_wait_healthy.sh
+++ b/oacis_wait_healthy.sh
@@ -1,0 +1,86 @@
+#!/bin/bash -eu
+
+cd "$(dirname "$0")"
+
+HEALTH_TIMEOUT=${OACIS_HEALTH_TIMEOUT:-600}
+POLL_INTERVAL=${OACIS_HEALTH_POLL_INTERVAL:-2}
+LOG_LINES=${OACIS_HEALTH_LOG_LINES:-200}
+
+if ! [[ "${HEALTH_TIMEOUT}" =~ ^[0-9]+$ ]] || [ "${HEALTH_TIMEOUT}" -eq 0 ]; then
+  echo "OACIS_HEALTH_TIMEOUT must be a positive integer (seconds)." >&2
+  exit 2
+fi
+if ! [[ "${POLL_INTERVAL}" =~ ^[0-9]+$ ]] || [ "${POLL_INTERVAL}" -eq 0 ]; then
+  echo "OACIS_HEALTH_POLL_INTERVAL must be a positive integer (seconds)." >&2
+  exit 2
+fi
+if ! [[ "${LOG_LINES}" =~ ^[0-9]+$ ]] || [ "${LOG_LINES}" -eq 0 ]; then
+  echo "OACIS_HEALTH_LOG_LINES must be a positive integer." >&2
+  exit 2
+fi
+
+if [ "$#" -eq 0 ]; then
+  set -- oacis
+fi
+
+show_diagnostics() {
+  echo
+  echo "===== docker compose ps =====" >&2
+  docker compose ps -a >&2 || true
+  echo
+  echo "===== recent service logs =====" >&2
+  docker compose logs --tail "${LOG_LINES}" oacis mongo redis >&2 || true
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  show_diagnostics
+  exit 1
+}
+
+SECONDS=0
+echo "Waiting up to ${HEALTH_TIMEOUT}s for services to become healthy: $*"
+
+while true; do
+  all_healthy=true
+
+  for service in "$@"; do
+    container_id=$(docker compose ps -q "${service}")
+    if [ -z "${container_id}" ]; then
+      fail "No container found for service '${service}'."
+    fi
+
+    state=$(docker inspect --format '{{.State.Status}}' "${container_id}") \
+      || fail "Could not inspect service '${service}'."
+    health=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "${container_id}") \
+      || fail "Could not inspect health for service '${service}'."
+
+    case "${state}:${health}" in
+      running:healthy)
+        ;;
+      running:starting)
+        all_healthy=false
+        ;;
+      running:unhealthy)
+        fail "Service '${service}' is unhealthy."
+        ;;
+      running:none)
+        fail "Service '${service}' has no healthcheck."
+        ;;
+      *)
+        fail "Service '${service}' is not running (state=${state}, health=${health})."
+        ;;
+    esac
+  done
+
+  if [ "${all_healthy}" = true ]; then
+    echo "Services are healthy: $*"
+    exit 0
+  fi
+
+  if [ "${SECONDS}" -ge "${HEALTH_TIMEOUT}" ]; then
+    fail "Timed out after ${HEALTH_TIMEOUT}s waiting for services: $*"
+  fi
+
+  sleep "${POLL_INTERVAL}"
+done


### PR DESCRIPTION
## Summary

- replace the MongoDB 8.0 release candidate image with the stable `mongo:8.0.10` image
- add healthchecks for MongoDB, Redis, and OACIS, and gate OACIS startup on healthy dependencies
- replace the unbounded `OACIS READY` log wait with a shared, configurable health timeout and failure diagnostics
- strengthen CI to validate service health, runtime versions, HTTP availability, and the MCP JSON-RPC protocol
- run CI for pushes to all branches and PRs targeting `master`, while canceling stale runs for the same branch
- document container health checks, startup timeouts, and troubleshooting

## Why

The previous setup used a MongoDB release candidate, allowed OACIS to start before its dependencies were ready, and could wait forever for a log message. CI checked the web UI and Ruby version but did not verify actual Docker health status, dependency versions, or MCP startup.

## User impact

`oacis_boot.sh` and `oacis_start.sh` now return only after OACIS is healthy, or fail with a non-zero status after a configurable timeout. Failures include `docker compose ps` and recent MongoDB, Redis, and OACIS logs. The existing Result bind mount and MongoDB volume layout are unchanged.

This PR does not pin the OACIS image tag, OACIS Git source reference, Ruby base image, or xsub version.

## Validation

- `bash -n oacis_boot.sh oacis_start.sh oacis_wait_healthy.sh oacis_mcp.sh`
- GitHub Actions YAML parsing
- `docker compose config --quiet`, including a CI-like environment without `.env`
- `git diff --check`
- isolated fresh-volume Compose boot with all three services healthy
- MongoDB `8.0.10`, Redis `8.0.1`, and Ruby `3.4.10` runtime checks
- HTTP 200 from both the host and inside the OACIS container
- MCP `initialize` and `tools/list` responses with protocol-only stdout
- isolated end-to-end runs of both `oacis_boot.sh` and `oacis_start.sh`
