### PR TITLE
oacis_mcp.sh: map container result paths to host paths

### DIFF
--- a/oacis_mcp.sh
+++ b/oacis_mcp.sh
@@ -29,4 +29,8 @@ do
 done
 
 # -T: no TTY. stdout/stdin are used for the MCP stdio protocol.
-exec docker compose exec -T -u oacis oacis /home/oacis/oacis/bin/oacis_mcp
+# OACIS_MCP_DIR_MAP: the Result directory is bind-mounted (see docker-compose.yml),
+# so tools report host paths and the agent can read result files directly.
+exec docker compose exec -T -u oacis \
+  -e OACIS_MCP_DIR_MAP="/home/oacis/oacis/public/Result_development=$(pwd)/Result" \
+  oacis /home/oacis/oacis/bin/oacis_mcp


### PR DESCRIPTION
## Summary

Companion to crest-cassia/oacis#793. The MCP server now reports each run/analysis result directory as `dir` so agents can read result files directly (binary files included). This PR sets `OACIS_MCP_DIR_MAP` in `oacis_mcp.sh` so the reported container paths (`/home/oacis/oacis/public/Result_development`) are rewritten to the bind-mounted `Result/` directory on the Docker host, where the agent actually runs.

## Test plan

- `./oacis_mcp.sh` still launches the stdio server via `docker compose exec`; the only change is the added `-e OACIS_MCP_DIR_MAP=...`
- Path rewriting itself is unit-tested in the oacis PR (`Serializers.map_dir` specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)