### PR TITLE
Force the pinned QEMU to replace pre-installed binfmt handlers

### DIFF
--- a/version_tagging.sh
+++ b/version_tagging.sh
@@ -32,11 +32,30 @@ if ! docker system info 2>/dev/null | grep -q 'Username:'; then
   docker login
 fi
 
-# ====== QEMU/binfmt (needed on Linux hosts; usually not needed on Docker Desktop for macOS) ======
-# Do not fail if this step fails (may not be required in some environments)
+# ====== QEMU/binfmt (needed to build a foreign architecture) ======
+# '--install' skips architectures that already have a handler, and the VM behind
+# the Docker daemon normally registers its own QEMU at boot (colima ships 7.0.0,
+# which segfaults gcc while native gems are compiled for amd64). Removing the
+# handlers first is therefore what actually makes BINFMT_IMAGE take effect.
+# Do not fail the build here: the step is unnecessary in some environments.
 if docker info --format '{{.OSType}}' | grep -qi linux; then
-  log "Setting up binfmt (QEMU) for Linux host - continuing even if it fails"
-  docker run --privileged --rm "${BINFMT_IMAGE}" --install all || true
+  log "Registering binfmt handlers from ${BINFMT_IMAGE}, replacing any pre-installed QEMU"
+  docker run --privileged --rm "${BINFMT_IMAGE}" --uninstall 'qemu-*' >/dev/null \
+    || log "WARNING: could not remove the pre-installed QEMU; a stale emulator may crash the compiler"
+  docker run --privileged --rm "${BINFMT_IMAGE}" --install all >/dev/null \
+    || log "WARNING: 'binfmt --install all' failed; cross-architecture builds may not work"
+
+  # Cheap smoke check: run a container for every target platform, which
+  # exercises the handler that was just registered. A broken registration then
+  # shows up here instead of ten minutes into a build that dies with
+  # 'Segmentation fault (core dumped)'.
+  for platform in ${PLATFORMS//,/$'\n'}; do
+    if docker run --rm --platform "${platform}" "${BINFMT_IMAGE}" --version >/dev/null 2>&1; then
+      log "  ${platform}: OK"
+    else
+      log "  ${platform}: WARNING - cannot run a container for this platform"
+    fi
+  done
 fi
 
 # ====== Prepare buildx builder ======


### PR DESCRIPTION
`docker run tonistiigi/binfmt --install all` silently skips architectures that already have a registered handler. Where the VM behind the Docker daemon registers its own QEMU at boot — colima registers **QEMU 7.0.0 (2022)** — the `qemu-v8.1.5` pin in `version_tagging.sh` therefore never took effect, and `gcc` segfaulted while compiling native gems for the emulated amd64 leg.

That is what happened during the v4.0.0 release build: three consecutive runs died at `sassc`, `bson` and `prism` with `Segmentation fault (core dumped)`. Uninstalling the stale handlers by hand and re-installing from the pinned image made the next build pass.

This change:
- uninstalls the `qemu-*` handlers before `--install all`, so the pinned image really becomes the emulator (handlers are re-created on every run, so it is safe to repeat);
- warns instead of failing if either step is not permitted;
- runs a container for each target platform afterwards, so a broken registration shows up in a second rather than ten minutes into a build.

Verified on colima: the handlers are replaced and both `linux/amd64` and `linux/arm64` report OK.